### PR TITLE
Add title plugin for podcast episode title generation

### DIFF
--- a/plugins/title.yaml
+++ b/plugins/title.yaml
@@ -1,14 +1,14 @@
 description: Generate podcast episode titles from transcripts
 run: always  # always, matching
+model: gemma3
 output_extension: .txt  # Explicitly set text extension
 prompt: |
   Based on the following transcript, create a compelling podcast episode title. The title should be:
-  1. Engaging and attention-grabbing
-  2. Descriptive of the main topic or theme
-  3. Appropriate for a podcast episode
-  4. Between 3-8 words
-  5. Not too long or too short
-
+  1. Descriptive of the main topic or theme
+  2. Appropriate for a podcast episode
+  3. Between 1-8 words
+  4. Not too long or too short
+  
   Focus on the key themes, insights, or main discussion points from the transcript.
 
   Transcript:
@@ -17,4 +17,7 @@ prompt: |
   Summary:
   {summary}
 
-  Podcast Episode Title:
+  Do NOT give multiple options.
+  Do NOT output anything else.
+  Do NOT add any other text.
+  Do NOT add quotation marks.

--- a/plugins/title.yaml
+++ b/plugins/title.yaml
@@ -1,0 +1,20 @@
+description: Generate podcast episode titles from transcripts
+run: always  # always, matching
+output_extension: .txt  # Explicitly set text extension
+prompt: |
+  Based on the following transcript, create a compelling podcast episode title. The title should be:
+  1. Engaging and attention-grabbing
+  2. Descriptive of the main topic or theme
+  3. Appropriate for a podcast episode
+  4. Between 3-8 words
+  5. Not too long or too short
+
+  Focus on the key themes, insights, or main discussion points from the transcript.
+
+  Transcript:
+  {transcript}
+
+  Summary:
+  {summary}
+
+  Podcast Episode Title:


### PR DESCRIPTION
This PR adds a new title plugin that generates compelling podcast episode titles from audio transcripts using the `gemma3` model. The plugin follows the existing plugin architecture and automatically creates a titles/ output directory. It generates engaging, descriptive titles between 1-8 words focused on the key themes and insights from each transcript.

• Creates new title plugin with `gemma3` model configuration
• Generates podcast episode titles in `titles/` directory
• Integrates seamlessly with existing plugin system