### PR TITLE
Add FORCE_LANGUAGE support for whisper transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,21 @@ All PRs must pass linting checks before they can be merged. The GitHub Actions w
 - Use whatever you want to look at the markdown/output files (I use [Zettel Notes](https://www.zettelnotes.com/))
 - Run the `./watch.sh` script on an idle machine to get the most out of it
 
+### Transcription options
+
+You can control Whisper transcription via environment variables:
+
+- `WHISPER_MODEL`: Choose the Whisper model (e.g., `base`, `small`, `medium`, `large-v3`). Models with the `.en` suffix are English-only (e.g., `base.en`).
+- `FORCE_LANGUAGE`: Force a specific language for transcription. When set, VibeLine will call Whisper with `--language <code>`. For example, to force English:
+
+  ```bash
+  export FORCE_LANGUAGE=en
+  # or per-run
+  FORCE_LANGUAGE=en ./transcribe.sh VoiceMemos/your-file.m4a
+  ```
+
+If `FORCE_LANGUAGE` is unset, Whisper will auto-detect the language.
+
 ### Transcript Cleaning
 
 VibeLine includes a transcript cleaning feature that corrects common transcription errors based on customizable vocabulary files. This is especially useful for technical terms, names, or domain-specific jargon that speech recognition models often misinterpret.

--- a/transcribe.sh
+++ b/transcribe.sh
@@ -12,6 +12,12 @@ shift $((OPTIND-1))
 # Load environment variables
 [ -f .env ] && source .env
 
+# Optional language override via environment variable
+language_flag=""
+if [ -n "${FORCE_LANGUAGE:-}" ]; then
+    language_flag=(--language "$FORCE_LANGUAGE")
+fi
+
 # Check if a file argument was provided
 if [ $# -ne 1 ]; then
     echo "Usage: $0 [-f] <audio_file>"
@@ -59,10 +65,10 @@ duration_minutes=$(echo "$duration / 60" | bc -l)
 # Set output format based on duration
 if (( $(echo "$duration_minutes > 21" | bc -l) )); then
     # For files longer than 21 minutes, produce all formats
-    whisper "$input_file" --model $WHISPER_MODEL --output_dir "$TRANSCRIPT_DIR"
+    whisper "$input_file" --model $WHISPER_MODEL --output_dir "$TRANSCRIPT_DIR" ${language_flag[@]}
 else
     # For shorter files, produce only txt format
-    whisper "$input_file" --model $WHISPER_MODEL --output_dir "$TRANSCRIPT_DIR" --output_format txt
+    whisper "$input_file" --model $WHISPER_MODEL --output_dir "$TRANSCRIPT_DIR" --output_format txt ${language_flag[@]}
 fi
 
 # Deactivate the virtual environment

--- a/transcribe.sh
+++ b/transcribe.sh
@@ -16,6 +16,7 @@ shift $((OPTIND-1))
 language_flag=""
 if [ -n "${FORCE_LANGUAGE:-}" ]; then
     language_flag=(--language "$FORCE_LANGUAGE")
+    echo "INFO: FORCE_LANGUAGE=$FORCE_LANGUAGE set, using whisper --language=$FORCE_LANGUAGE"
 fi
 
 # Check if a file argument was provided


### PR DESCRIPTION
Adds support for forcing a specific language during transcription by setting the FORCE_LANGUAGE environment variable. When set, this passes the --language flag to whisper, allowing users to override auto-detection and force transcription in a specific language like English.

- Adds FORCE_LANGUAGE environment variable support in transcribe.sh
- Includes INFO logging to show when language forcing is active
- Updates README with usage instructions and examples