### PR TITLE
fix: handle punctuation in DM wake phrases

### DIFF
--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -52,9 +52,9 @@ fi
 
 TRANSCRIPT=$(cat "$TRANSCRIPT_FILE")
 
-# Extract the name right after "hey" (case-insensitive, macOS sed compatible).
-# Allow punctuation like "hey, sven" in addition to "hey sven".
-HEY_NAME=$(printf '%s\n' "$TRANSCRIPT" | sed -n 's/.*[Hh][Ee][Yy][[:space:]]*[-,.:;!?]*[[:space:]]*\([A-Za-z][A-Za-z]*\).*/\1/p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')
+# Extract the name right after a standalone "hey" (case-insensitive, macOS sed compatible).
+# Prepending a space lets us treat start-of-line like any other non-letter boundary.
+HEY_NAME=$(printf ' %s\n' "$TRANSCRIPT" | sed -n 's/.*[^[:alpha:]][Hh][Ee][Yy][[:space:]]*[-,.:;!?]*[[:space:]]*\([A-Za-z][A-Za-z]*\).*/\1/p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')
 
 if [[ -z "$HEY_NAME" ]]; then
     echo "No 'Hey <name>' pattern found in transcript" >&2

--- a/scripts/dm.sh
+++ b/scripts/dm.sh
@@ -52,8 +52,9 @@ fi
 
 TRANSCRIPT=$(cat "$TRANSCRIPT_FILE")
 
-# Extract the name right after "hey" (case-insensitive, no PCRE for macOS compat)
-HEY_NAME=$(echo "$TRANSCRIPT" | sed -n 's/.*[Hh][Ee][Yy][[:space:]][[:space:]]*\([A-Za-z][A-Za-z]*\).*/\1/p' | head -1 | tr '[:upper:]' '[:lower:]')
+# Extract the name right after "hey" (case-insensitive, macOS sed compatible).
+# Allow punctuation like "hey, sven" in addition to "hey sven".
+HEY_NAME=$(printf '%s\n' "$TRANSCRIPT" | sed -n 's/.*[Hh][Ee][Yy][[:space:]]*[-,.:;!?]*[[:space:]]*\([A-Za-z][A-Za-z]*\).*/\1/p' | sed -n '1p' | tr '[:upper:]' '[:lower:]')
 
 if [[ -z "$HEY_NAME" ]]; then
     echo "No 'Hey <name>' pattern found in transcript" >&2


### PR DESCRIPTION
This updates the DM trigger parsing so transcripts like `hey, sven` and `Hey: Sven` are treated the same as `hey sven`, preventing missed contact matches when speech-to-text inserts punctuation after `hey`.

- broadens the `sed` matcher to allow common punctuation between `hey` and the contact name
- keeps the existing single-name extraction behavior intact
- preserves the current macOS-compatible shell approach in `scripts/dm.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript name extraction to recognize voice commands with punctuation (e.g., "hey, sven") and enhanced cross-platform compatibility for more reliable command recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->