### PR TITLE
fix: keep extract pipeline running when a plugin's model fails

### DIFF
--- a/plugins/shownote.yaml
+++ b/plugins/shownote.yaml
@@ -2,7 +2,7 @@ name: shownote
 description: Generate concise podcast show notes from transcripts
 run: matching
 keywords: ["good morning", "leave it at that"]
-model: gpt-oss
+model: llama3.2
 output_extension: .md  # Markdown output
 prompt: |
   You are a podcast producer. Create concise, useful show notes based on the transcript.

--- a/plugins/title.yaml
+++ b/plugins/title.yaml
@@ -1,6 +1,6 @@
 description: Generate podcast episode titles from transcripts
 run: always  # always, matching
-model: gpt-oss
+model: llama3.2
 output_extension: .txt  # Explicitly set text extension
 prompt: |
   Transcript:

--- a/src/extract.py
+++ b/src/extract.py
@@ -341,14 +341,19 @@ def main() -> None:
 
             # Generate content only if plugin has a non-empty prompt
             if plugin.prompt and plugin.prompt.strip():
-                additional_content = generate_additional_content(
-                    plugin.prompt, transcript_text, summary_text, plugin.model
-                )
+                try:
+                    additional_content = generate_additional_content(
+                        plugin.prompt, transcript_text, summary_text, plugin.model
+                    )
 
-                # Save to appropriate directory using base filename
-                with open(output_file, "w", encoding="utf-8") as f:
-                    f.write(additional_content)
-                logger.info(f"Content saved to: {output_file}")
+                    # Save to appropriate directory using base filename
+                    with open(output_file, "w", encoding="utf-8") as f:
+                        f.write(additional_content)
+                    logger.info(f"Content saved to: {output_file}")
+                except Exception as gen_err:
+                    # Don't let one failing plugin abort the whole run; skip and continue
+                    logger.error(f"Failed to generate content for {plugin_name} plugin: {gen_err}")
+                    continue
             else:
                 logger.info(f"Skipping generation for {plugin_name} (no prompt provided)")
 


### PR DESCRIPTION
Fixes the extract pipeline breaking on every voice memo. The `title` and `shownote` plugins were pinned to `gpt-oss`, whose blob is an outdated MXFP4 GGUF that current Ollama can no longer load, so `title` (which runs `always`) failed on every run and its unhandled exception aborted the whole extract, taking every later plugin down with it. Both plugins now use `llama3.2`, and plugin generation is wrapped so a single failure is logged and skipped instead of crashing the run.

- Switch `title.yaml` and `shownote.yaml` from `gpt-oss` to `llama3.2`
- Wrap content generation in `extract.py` so one failing plugin no longer aborts the run
