### PR TITLE
fix(archive): ensure logs dir exists for cron redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ yarn-debug.log*
 yarn-error.log*
 *.swp
 
+# Cron logs (keep the dir, ignore the logs)
+logs/*.log
+
 # Python build artifacts
 *.egg-info/
 dist/


### PR DESCRIPTION
The monthly archive cron job silently failed on every run because it redirected output to `logs/archive.log` while the `logs/` directory did not exist, so the shell aborted the redirect before `archive.sh` could run. This tracks the `logs/` directory in git and ignores the log files themselves so the cron job works on a fresh clone.

- Add `logs/.gitkeep` so the directory is tracked and survives a fresh clone
- Ignore `logs/*.log` so log output stays out of git
